### PR TITLE
Support GHC 9.4

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,11 +1,2 @@
 write-ghc-environment-files: never
 packages: .
-
--- for template-haskell 2.18 support. only matters to the test suite,
--- and hackage ignores this file.
-source-repository-package
-  type: git
-  location: https://github.com/hedgehogqa/haskell-hedgehog
-  subdir:
-    hedgehog
-  tag: 21a5131d6cb2418f8a032759a69003dcb8cfdb30

--- a/vector-circular.cabal
+++ b/vector-circular.cabal
@@ -32,11 +32,11 @@ library
     Data.Vector.Circular
     Data.Vector.Circular.Generic
   build-depends:
-    , base >= 4.11 && < 4.17
+    , base >= 4.11 && < 4.18
     , nonempty-vector >= 0.2 && < 0.3
     , primitive >= 0.6.4 && < 0.8
     , semigroupoids >= 5.3 && < 5.4
-    , template-haskell >= 2.12 && < 2.19
+    , template-haskell >= 2.12 && < 2.20
     , vector >= 0.12 && < 0.13
     , deepseq >= 1.4 && < 1.5
   ghc-options:


### PR DESCRIPTION
After updating the bounds + removing the pinned hedgehog git checkout the package builds fine with ghc 9.4. 

Admittedly, I haven't run the testsuite (since hedgehog-classes does not seem to support 9.4 yet).