### PR TITLE
Fix dependencies for building with GHC 9.6

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,11 +1,2 @@
 write-ghc-environment-files: never
 packages: .
-
--- for template-haskell 2.18 support. only matters to the test suite,
--- and hackage ignores this file.
-source-repository-package
-  type: git
-  location: https://github.com/hedgehogqa/haskell-hedgehog
-  subdir:
-    hedgehog
-  tag: 21a5131d6cb2418f8a032759a69003dcb8cfdb30

--- a/src/Data/Vector/Circular.hs
+++ b/src/Data/Vector/Circular.hs
@@ -192,7 +192,7 @@ import Control.DeepSeq
 #endif /* MIN_VERSION_base(4,13,0) */
 import Data.List.NonEmpty (NonEmpty((:|)))
 import Data.Primitive.MutVar ( newMutVar, readMutVar, writeMutVar )
-import Data.Semigroup.Foldable.Class (Foldable1)
+import Data.Foldable1 (Foldable1)
 import Data.Monoid (All(..))
 import Data.Vector (Vector)
 import Data.Vector.NonEmpty (NonEmptyVector)
@@ -209,7 +209,7 @@ import Prelude hiding (head, length, last, map, concat, takeWhile
                       ,enumFromThenTo, (++), filter)
 import Language.Haskell.TH.Syntax
 import qualified Data.Foldable as Foldable
-import qualified Data.Semigroup.Foldable.Class as Foldable1
+import qualified Data.Foldable1 as Foldable1
 import qualified Data.Vector as Vector
 import qualified Data.Vector.Mutable as MVector
 import qualified Data.Vector.NonEmpty as NonEmpty

--- a/vector-circular.cabal
+++ b/vector-circular.cabal
@@ -32,11 +32,11 @@ library
     Data.Vector.Circular
     Data.Vector.Circular.Generic
   build-depends:
-    , base >= 4.11 && < 4.17
+    , base >= 4.11 && < 4.18
     , nonempty-vector >= 0.2 && < 0.3
     , primitive >= 0.6.4 && < 0.8
     , semigroupoids >= 5.3 && < 5.4
-    , template-haskell >= 2.12 && < 2.19
+    , template-haskell >= 2.12 && < 2.20
     , vector >= 0.12 && < 0.13
     , deepseq >= 1.4 && < 1.5
   ghc-options:

--- a/vector-circular.cabal
+++ b/vector-circular.cabal
@@ -32,12 +32,12 @@ library
     Data.Vector.Circular
     Data.Vector.Circular.Generic
   build-depends:
-    , base >= 4.11 && < 4.18
+    , base >= 4.11 && < 4.19
     , nonempty-vector >= 0.2 && < 0.3
     , primitive >= 0.6.4 && < 0.8
-    , semigroupoids >= 5.3 && < 5.4
-    , template-haskell >= 2.12 && < 2.20
-    , vector >= 0.12 && < 0.13
+    , semigroupoids >= 5.3 && < 6.1
+    , template-haskell >= 2.12 && < 2.21
+    , vector >= 0.12 && < 0.14
     , deepseq >= 1.4 && < 1.5
   ghc-options:
     -Wall

--- a/vector-circular.cabal
+++ b/vector-circular.cabal
@@ -36,6 +36,7 @@ library
     , nonempty-vector >= 0.2 && < 0.3
     , primitive >= 0.6.4 && < 0.8
     , semigroupoids >= 5.3 && < 6.1
+    , foldable1-classes-compat >= 0.1 && < 0.2
     , template-haskell >= 2.12 && < 2.21
     , vector >= 0.12 && < 0.14
     , deepseq >= 1.4 && < 1.5

--- a/vector-circular.cabal
+++ b/vector-circular.cabal
@@ -35,7 +35,6 @@ library
     , base >= 4.11 && < 4.19
     , nonempty-vector >= 0.2 && < 0.3
     , primitive >= 0.6.4 && < 0.8
-    , semigroupoids >= 5.3 && < 6.1
     , foldable1-classes-compat >= 0.1 && < 0.2
     , template-haskell >= 2.12 && < 2.21
     , vector >= 0.12 && < 0.14


### PR DESCRIPTION
Bumping the dependencies seems sufficient to build with ghc 9.6 

It does build with a warning about the Foldable1 class now being available in Data.Foldable1. It might be good to fix that soon as well.